### PR TITLE
Move /hexdump back onto the server.

### DIFF
--- a/common/src/main/kotlin/io/github/jojotastic777/hexdump/Hexdump.kt
+++ b/common/src/main/kotlin/io/github/jojotastic777/hexdump/Hexdump.kt
@@ -1,7 +1,20 @@
 package io.github.jojotastic777.hexdump
 
+import at.petrak.hexcasting.api.casting.ActionRegistryEntry
+import at.petrak.hexcasting.api.mod.HexTags
+import at.petrak.hexcasting.api.utils.isOfTag
+import at.petrak.hexcasting.common.casting.PatternRegistryManifest
+import at.petrak.hexcasting.xplat.IXplatAbstractions
+import com.mojang.brigadier.context.CommandContext
+import dev.architectury.event.events.common.CommandRegistrationEvent
 import io.github.jojotastic777.hexdump.config.HexdumpConfig
 import io.github.jojotastic777.hexdump.networking.HexdumpNetworking
+import io.github.jojotastic777.hexdump.networking.msg.PatternDumpS2C
+import net.minecraft.commands.CommandSourceStack
+import net.minecraft.commands.Commands
+import net.minecraft.commands.Commands.literal
+import net.minecraft.core.Registry
+import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -15,8 +28,73 @@ object Hexdump {
     @JvmStatic
     fun id(path: String) = ResourceLocation(MODID, path)
 
+    fun dumpPatterns(registry: Registry<ActionRegistryEntry>, ctx: CommandContext<CommandSourceStack>, includePerWorldPatterns: Boolean) {
+        val player = ctx.source.player
+        if (player == null) { return }
+
+        val patterns = HashMap<String, PatternDump.DumpEntry>()
+
+        for (id in registry.registryKeySet()) {
+            val action = registry.get(id)
+            if (action == null) continue
+
+            val isPerWorld = isOfTag(registry, id, HexTags.Actions.PER_WORLD_PATTERN)
+
+            if (!includePerWorldPatterns && isPerWorld) { continue }
+
+            val pat = if (isPerWorld) {
+                val foundPat = PatternRegistryManifest.getCanonicalStrokesPerWorld(id, ctx.source.server.overworld())
+                if (foundPat == null) continue
+
+                PatternDump.DumpEntry(
+                    id = id.location().toString(),
+                    name = Component.translatable("hexcasting.action.${id.location()}").string,
+                    startDir = foundPat.startDir.toString(),
+                    angles = foundPat.anglesSignature(),
+                    isPerWorld = true
+                )
+            } else {
+                PatternDump.DumpEntry(
+                    id = id.location().toString(),
+                    name = Component.translatable("hexcasting.action.${id.location()}").string,
+                    startDir = action.prototype.startDir.toString(),
+                    angles = action.prototype.anglesSignature(),
+                    isPerWorld = false
+                )
+            }
+
+            patterns[id.location().toString()] = pat
+        }
+
+        PatternDumpS2C(patterns).sendToPlayer(player)
+    }
+
     fun init() {
         HexdumpConfig.init()
         HexdumpNetworking.init()
+
+        val actionsRegistry = IXplatAbstractions.INSTANCE.actionRegistry
+
+        CommandRegistrationEvent.EVENT.register { dispatcher, _, _ ->
+            dispatcher.register(literal("hexdump_net")
+                .executes { context ->
+                    dumpPatterns(actionsRegistry, context, false)
+
+                    context.source.sendSuccess({-> Component.literal("Success.")}, false)
+
+                    1
+                }
+                .then(literal("with-world-patterns")
+                    .requires { source -> source.hasPermission(Commands.LEVEL_ADMINS) }
+                    .executes { context ->
+                        dumpPatterns(actionsRegistry, context, true)
+
+                        context.source.sendSuccess({-> Component.literal("Success.")}, false)
+
+                        1
+                    }
+                )
+            )
+        }
     }
 }

--- a/common/src/main/kotlin/io/github/jojotastic777/hexdump/HexdumpClient.kt
+++ b/common/src/main/kotlin/io/github/jojotastic777/hexdump/HexdumpClient.kt
@@ -1,73 +1,13 @@
 package io.github.jojotastic777.hexdump
 
-import at.petrak.hexcasting.api.casting.ActionRegistryEntry
-import at.petrak.hexcasting.api.mod.HexTags
-import at.petrak.hexcasting.api.utils.isOfTag
-import at.petrak.hexcasting.xplat.IXplatAbstractions
-import com.google.gson.Gson
-import dev.architectury.event.events.client.ClientCommandRegistrationEvent
-import dev.architectury.event.events.client.ClientCommandRegistrationEvent.literal
 import io.github.jojotastic777.hexdump.config.HexdumpConfig
 import io.github.jojotastic777.hexdump.config.HexdumpConfig.GlobalConfig
 import me.shedaniel.autoconfig.AutoConfig
 import net.minecraft.client.gui.screens.Screen
-import net.minecraft.commands.Commands
-import net.minecraft.core.Registry
-import net.minecraft.network.chat.Component
 
 object HexdumpClient {
-    fun dumpPatterns(registry: Registry<ActionRegistryEntry>, includePerWorldPatterns: Boolean) {
-        val gson = Gson()
-
-        val patterns = HashMap<String, Any>()
-
-        for (id in registry.registryKeySet()) {
-            val action = registry.get(id)
-            if (action == null) {  continue }
-
-            val isPerWorld = isOfTag(registry, id, HexTags.Actions.PER_WORLD_PATTERN)
-
-            if (!includePerWorldPatterns && isPerWorld) { continue }
-
-            val pat = object {
-                val id = id.location().toString()
-                val name = Component.translatable("hexcasting.action.${id.location()}").string
-                val startDir = action.prototype.startDir
-                val angles = action.prototype.anglesSignature()
-                val isPerWorld = isPerWorld
-            }
-
-            patterns[id.location().toString()] = pat
-        }
-
-        val file = java.io.File("patterns.json")
-        file.writeText(gson.toJson(patterns))
-    }
-
     fun init() {
         HexdumpConfig.initClient()
-
-        val actionsRegistry = IXplatAbstractions.INSTANCE.actionRegistry
-
-        ClientCommandRegistrationEvent.EVENT.register { dispatcher, _ ->
-            dispatcher.register(literal("hexdump")
-                .executes { context ->
-                    dumpPatterns(actionsRegistry, false)
-
-                    context.source.`arch$sendSuccess`({-> Component.literal("Dumped actions registry to patterns.json")}, false)
-
-                    1
-                }
-                .then(literal("with-per-world")
-                    .requires { source -> source.hasPermission(Commands.LEVEL_ADMINS) }
-                    .executes { context ->
-                        dumpPatterns(actionsRegistry, true)
-
-                        context.source.`arch$sendSuccess`({-> Component.literal("Dumped actions registry to patterns.json")}, false)
-
-                        1
-                    }))
-        }
 
     }
 

--- a/common/src/main/kotlin/io/github/jojotastic777/hexdump/PatternDump.kt
+++ b/common/src/main/kotlin/io/github/jojotastic777/hexdump/PatternDump.kt
@@ -1,0 +1,39 @@
+package io.github.jojotastic777.hexdump
+
+import com.google.gson.Gson
+import net.minecraft.network.FriendlyByteBuf
+import java.io.File
+
+object PatternDump {
+    fun onPatternDump(patterns: Map<String, DumpEntry>) {
+        val gson = Gson()
+        val file = File("net-patterns.json")
+        file.writeText(gson.toJson(patterns))
+    }
+
+    data class DumpEntry(
+        val id: String,
+        val name: String,
+        val startDir: String,
+        val angles: String,
+        val isPerWorld: Boolean
+    ) {
+        fun encode(buf: FriendlyByteBuf) {
+            buf.writeUtf(id)
+            buf.writeUtf(name)
+            buf.writeUtf(startDir)
+            buf.writeUtf(angles)
+            buf.writeBoolean(isPerWorld)
+        }
+
+        companion object {
+            fun decode(buf: FriendlyByteBuf) = DumpEntry(
+                id = buf.readUtf(),
+                name = buf.readUtf(),
+                startDir = buf.readUtf(),
+                angles = buf.readUtf(),
+                isPerWorld = buf.readBoolean()
+            )
+        }
+    }
+}

--- a/common/src/main/kotlin/io/github/jojotastic777/hexdump/networking/handler/ClientMessageHandler.kt
+++ b/common/src/main/kotlin/io/github/jojotastic777/hexdump/networking/handler/ClientMessageHandler.kt
@@ -1,6 +1,7 @@
 package io.github.jojotastic777.hexdump.networking.handler
 
 import dev.architectury.networking.NetworkManager.PacketContext
+import io.github.jojotastic777.hexdump.PatternDump
 import io.github.jojotastic777.hexdump.config.HexdumpConfig
 import io.github.jojotastic777.hexdump.networking.msg.*
 
@@ -8,6 +9,10 @@ fun HexdumpMessageS2C.applyOnClient(ctx: PacketContext) = ctx.queue {
     when (this) {
         is MsgSyncConfigS2C -> {
             HexdumpConfig.onSyncConfig(serverConfig)
+        }
+
+        is PatternDumpS2C -> {
+            PatternDump.onPatternDump(patterns)
         }
 
         // add more client-side message handlers here

--- a/common/src/main/kotlin/io/github/jojotastic777/hexdump/networking/msg/PatternDumpS2C.kt
+++ b/common/src/main/kotlin/io/github/jojotastic777/hexdump/networking/msg/PatternDumpS2C.kt
@@ -1,0 +1,25 @@
+package io.github.jojotastic777.hexdump.networking.msg
+
+import net.minecraft.network.FriendlyByteBuf
+import io.github.jojotastic777.hexdump.PatternDump.DumpEntry
+
+data class PatternDumpS2C(val patterns: Map<String, DumpEntry>) : HexdumpMessageS2C {
+    companion object : HexdumpMessageCompanion<PatternDumpS2C> {
+        override val type = PatternDumpS2C::class.java
+
+        override fun decode(buf: FriendlyByteBuf) = PatternDumpS2C(
+            patterns = buf.readMap<String, DumpEntry>(
+                { b -> b.readUtf() },
+                { b -> DumpEntry.decode(b) }
+            )
+        )
+
+        override fun PatternDumpS2C.encode(buf: FriendlyByteBuf) {
+            buf.writeMap<String, DumpEntry>(
+                patterns,
+                { b, key -> b.writeUtf(key) },
+                { b, value -> value.encode(b) }
+            )
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ kotlin.stdlib.default.dependency=false
 # mod info
 mavenGroup=io.github.jojotastic777.hexdump
 modId=hexdump
-modVersion=0.2.0
+modVersion=0.3.0
 
 # game version for hexdoc
 minecraftVersion=1.20.1


### PR DESCRIPTION
The command *needs* to be running on the server in order to properly get the values of per-world patterns.

The trouble is, you can't write to the client's `.minecraft` folder from the server. This doesn't really matter in singleplayer, since in that context the client's `.minecraft` and the server's are the same. On servers, however, this means that the mod would end up writing to the *server's* `.minecraft` directory, which isn't really helpful for people playing on the server.

My initial solution to this was to just move the whole command onto the client, which *does* fix the problem. The issue with this is that you can't get the correct stroke orders for per-world patterns on the client. So, running the command on the client means that you either can't get per-world patterns, or worse, the per-world patterns you get will be *wrong,* as seen in #5.

The *correct* way to fix this, I'm fairly sure, is to run the `/hexdump` command on the server and the send a network message to the client containing a map of registry names to pattern data and have the *client* handle writing that data to disk.

The problem with this is that I have to figure out networking.